### PR TITLE
making compatible with Alloy 6

### DIFF
--- a/c11_perturbed.als
+++ b/c11_perturbed.als
@@ -275,7 +275,7 @@ pred transitive[rel: Event->Event]        { rel = ^rel }
 pred irreflexive[rel: Event->Event]        { no iden & rel }
 pred acyclic[rel: Event->Event]            { irreflexive[^rel] }
 pred total[rel: Event->Event, bag: Event] {
-  all disj e, e': bag | e->e' in rel + ~rel
+  all disj e, e2: bag | e->e2 in rel + ~rel
   acyclic[rel]
 }
 

--- a/power_perturbed.als
+++ b/power_perturbed.als
@@ -250,7 +250,7 @@ fun coe_p[p: PTag->univ] : MemoryEvent->MemoryEvent { co_p[p] - coi_p[p] }
 pred irreflexive[rel: Event->Event]        { no iden & rel }
 pred acyclic[rel: Event->Event]            { irreflexive[^rel] }
 pred total[rel: Event->Event, bag: Event] {
-  all disj e, e': bag | e->e' in rel + ~rel
+  all disj e, e2: bag | e->e2 in rel + ~rel
   acyclic[rel]
 }
 

--- a/scc_perturbed_scflip.als
+++ b/scc_perturbed_scflip.als
@@ -203,7 +203,7 @@ fun coe_p[p: PTag->univ] : MemoryEvent->MemoryEvent { co_p[p] - coi_p[p] }
 pred irreflexive[rel: Event->Event]        { no iden & rel }
 pred acyclic[rel: Event->Event]            { irreflexive[^rel] }
 pred total[rel: Event->Event, bag: Event] {
-  all disj e, e': bag | e->e' in rel + ~rel
+  all disj e, e2: bag | e->e2 in rel + ~rel
   acyclic[rel]
 }
 

--- a/tso_perturbed.als
+++ b/tso_perturbed.als
@@ -151,7 +151,7 @@ fun coe_p[p: PTag->univ] : MemoryEvent->MemoryEvent { co_p[p] - coi_p[p] }
 pred irreflexive[rel: Event->Event]        { no iden & rel }
 pred acyclic[rel: Event->Event]            { irreflexive[^rel] }
 pred total[rel: Event->Event, bag: Event] {
-  all disj e, e': bag | e->e' in rel + ~rel
+  all disj e, e2: bag | e->e2 in rel + ~rel
   acyclic[rel]
 }
 


### PR DESCRIPTION
Alloy 6 doesn't allow single-quotes in identifiers any more, like `x'`. (This is because `'` is now a temporal operator, so `x'` means "`x` in the next state".) I've fixed up the `.als` files in this repo (just needed to change `e'` into `e2`), so they now compile fine with Alloy 6.